### PR TITLE
add link to goteborg stad (stadsnaraodling)

### DIFF
--- a/content/pages/sammarbeten.md
+++ b/content/pages/sammarbeten.md
@@ -19,4 +19,4 @@ status: published
 För Klimatet (IFK)</a>
 * <a href="https://stadsdelsvaxthus.se" target="_blank">Stadsdelsväxthus i Majorna</a>
 * <a href="https://bidgamlestaden.se/" target="_blank">BID Gamlestaden</a>
-* Göteborgs kommun
+* <a href="https://stadsnaraodling.goteborg.se/" target="_blank">Göteborgs kommun</a>


### PR DESCRIPTION
All the other collaborators have a link so I figured it would make sense to add one for Gothenburg City too. Their subdomain dealing with city agriculture seemed appropriate.